### PR TITLE
Added Fix for Strict Standards, wrapped the explode in a variable. 

### DIFF
--- a/hammy.php
+++ b/hammy.php
@@ -11,8 +11,10 @@ Author URI: http://www.noeltock.com
 /**
  * Defines
  */
-define ( 'HAMMY_VERSION', '1.2' );
-define ( 'HAMMY_PATH',  WP_PLUGIN_URL . '/' . end( explode( DIRECTORY_SEPARATOR, dirname( __FILE__ ) ) ) );
+
+define ( 'HAMMY_VERSION', '1.3.2' );
+$exp = explode( DIRECTORY_SEPARATOR, dirname( __FILE__ ) );
+define ( 'HAMMY_PATH',  WP_PLUGIN_URL . '/' . end( $exp ) );
 
 /**
  * Register Default Settings


### PR DESCRIPTION
WP Thumb should also be updated to avoid errors in WP 3.6. 

Just added a new variable to adhere to the latest PHP version. I was getting a Strict Standards message when running the plugin in debug mode. I'm getting the same message on the front-end from WP Thumb, but updating to the newest version of it fixed that as well.
